### PR TITLE
Update PDO connection of MySQL

### DIFF
--- a/ice/db/driver/pdo.zep
+++ b/ice/db/driver/pdo.zep
@@ -38,7 +38,7 @@ class Pdo implements DbInterface
         preg_match("/^.+?(?:dbname|database)=(.+?)(?=;|$)/i", dsn, parts);
 
         if isset parts[0] && strstr(parts[0], ":", TRUE) == "mysql" {
-            let options[\PDO::MYSQL_ATTR_INIT_COMMAND] = "SET NAMES utf8;";
+            dsn = dsn . ";charset=utf8";
         }
 
         let pdo = "Pdo",

--- a/ice/db/driver/pdo.zep
+++ b/ice/db/driver/pdo.zep
@@ -38,7 +38,7 @@ class Pdo implements DbInterface
         preg_match("/^.+?(?:dbname|database)=(.+?)(?=;|$)/i", dsn, parts);
 
         if isset parts[0] && strstr(parts[0], ":", TRUE) == "mysql" {
-            dsn = dsn . ";charset=utf8";
+            let dsn = dsn . ";charset=utf8";
         }
 
         let pdo = "Pdo",


### PR DESCRIPTION
Prior to PHP version 5.3.6, charset of DSN was ignored.
But Ice framework required PHP version 5.4 or newer.
So we can use "charset:utf8" instead of "SET NAMES utf8".

http://php.net/manual/en/ref.pdo-mysql.connection.php
http://php.net/manual/en/mysqlinfo.concepts.charset.php
