### PR TITLE
toString() must return a string value

### DIFF
--- a/ice/http/response.zep
+++ b/ice/http/response.zep
@@ -411,6 +411,6 @@ class Response implements ResponseInterface
      */
     public function __toString() -> string
     {
-        return this->body;
+        return (string) this->body;
     }
 }


### PR DESCRIPTION
__toString() must return a string value