### PR TITLE
Model, enhanced and bug fixed

### DIFF
--- a/ice/mvc/model.zep
+++ b/ice/mvc/model.zep
@@ -684,7 +684,7 @@ abstract class Model extends Arr implements \Serializable
             case self::BELONGS_TO:
             case self::HAS_ONE:
                 let filters = array_merge(filters, [referencedField: this->{field}]),
-                    result = create_instance_params(referenceModel, [filters]);
+                    result = create_instance_params(referenceModel, [filters, null, options]);
 
                 if !result->count() {
                     return false;

--- a/ice/mvc/model.zep
+++ b/ice/mvc/model.zep
@@ -33,6 +33,9 @@ abstract class Model extends Arr implements \Serializable
     protected rules = [];
     protected messages = [] { get, set };
 
+    // this model has been loaded from service
+    protected isLoaded = null;
+
     const BELONGS_TO = 1;
     const HAS_ONE = 2;
     const HAS_MANY = 3;
@@ -42,8 +45,9 @@ abstract class Model extends Arr implements \Serializable
      *
      * @param mixed filters
      * @param array data
+     * @param array options Options to limit/group/orderby results when filters is not null
      */
-    public function __construct(var filters = null, array data = [])
+    public function __construct(var filters = null, array data = [], array options = [])
     {
         var di;
 
@@ -68,9 +72,7 @@ abstract class Model extends Arr implements \Serializable
         }
 
         if filters {
-            if !this->loadOne(filters) {
-                throw new Exception("Not Found");
-            }
+            this->loadOne(filters, options);
         }
 
         if method_exists(this, "initialize") {
@@ -121,19 +123,25 @@ abstract class Model extends Arr implements \Serializable
      * Load one result to the current object.
      *
      * @param mixed filters
-     * @param array options
+     * @param array options Options to limit/group/orderby results
      * @return this|false
      */
     public function loadOne(var filters, array options = [])
     {
         var result;
 
+        if empty filters {
+            return false;
+        }
+
         let result = this->db->findOne(this->from, filters, options);
 
         if result {
             this->replace(result->all());
+            let this->isLoaded = true;
             return this;
         } else {
+            let this->isLoaded = false;
             return false;
         }
     }
@@ -147,14 +155,16 @@ abstract class Model extends Arr implements \Serializable
      */
     public function load(var filters, array options = [])
     {
-        var result, instances, data;
+        var result, instances, data, model;
 
         let result = this->db->find(this->from, filters, options),
             instances = [];
 
         if result->count() {
             for data in iterator(result) {
-                let instances[] = create_instance_params(get_called_class(), [null, data]);
+                let model = create_instance_params(get_called_class(), [null, data]),
+                    model->isLoaded = true,
+                    instances[] = model;
             }
         }
         return new Arr(instances);
@@ -178,13 +188,11 @@ abstract class Model extends Arr implements \Serializable
      */
     public static function findOne(var filters = null, array options = [])
     {
-        var result, model, instance;
+        var model;
 
-        let model = get_called_class(),
-            instance = create_instance(model),
-            result = instance->loadOne(filters, options);
+        let model = create_instance_params(get_called_class(), [filters, null, options]);
 
-        return result;
+        return model->isLoaded ? instance : false;
     }
 
     /**
@@ -201,13 +209,11 @@ abstract class Model extends Arr implements \Serializable
      */
     public static function find(var filters = null, array options = [])
     {
-        var result, model, instance;
+        var model;
 
-        let model = get_called_class(),
-            instance = create_instance(model),
-            result = instance->load(filters, options);
+        let model = new static;
 
-        return result;
+        return model->load(filters, options);
     }
 
     /**
@@ -220,16 +226,16 @@ abstract class Model extends Arr implements \Serializable
     protected function fields(var fields = [], boolean primary = true)
     {
         // Check if model has defined valid fields
-        if !count(this->fields) {
+        if empty this->fields {
             // No defined model's fields
             // Check if fields param has any elements
-            if !count(fields) {
+            if empty fields {
                 // Get all model's data as fields
                 let fields = this->all();
             } else {
                 // Get only fields from method parameter
                 // Check if fields param is associative or sequential
-                if count(array_filter(array_keys(fields), "is_string")) {
+                if array_filter(array_keys(fields), "is_string") {
                     // Merge model data with fields values
                     let fields = array_merge(this->all(), fields);
                 } else {
@@ -240,13 +246,13 @@ abstract class Model extends Arr implements \Serializable
         } else {
             // Only valid model's fields
             // Check if fields param has any elements
-            if !count(fields) {
+            if empty fields {
                 // Get all valid model's data as fields
                 let fields = array_intersect_key(this->all(), array_flip(this->fields));
             } else {
                 // Get only fields from method parameter
                 // Check if fields param is associative or sequential
-                if count(array_filter(array_keys(fields), "is_string")) {
+                if array_filter(array_keys(fields), "is_string") {
                     // Merge model data with fields values, get only valid model's fields
                     let fields = array_intersect_key(array_merge(this->all(), fields), array_flip(this->fields));
                 } else {
@@ -293,7 +299,7 @@ abstract class Model extends Arr implements \Serializable
         this->di->applyHook("model.before.validate", [this]);
 
         // Run validation if rules or validation is specified
-        if count(this->rules) || typeof this->validation == "object" && (this->validation instanceof Validation) {
+        if !empty this->rules || typeof this->validation == "object" && (this->validation instanceof Validation) {
             if !(typeof this->validation == "object" && (this->validation instanceof Validation)) {
                 let this->validation = new Validation();
             }
@@ -317,7 +323,7 @@ abstract class Model extends Arr implements \Serializable
 
         this->di->applyHook("model.after.validate", [this]);
 
-        if count(this->messages) {
+        if !empty this->messages {
             return false;
         }
 
@@ -326,7 +332,10 @@ abstract class Model extends Arr implements \Serializable
         let status = this->db->insert(this->from, this->getData());
 
         if status {
-            this->set(this->db->getId(), this->db->getLastInsertId());
+            let this->isLoaded = true;
+            if this->autoincrement {
+                this->set(this->db->getId(), this->db->getLastInsertId());
+            }
         }
 
         this->di->applyHook("model.after.create", [this]);
@@ -385,7 +394,7 @@ abstract class Model extends Arr implements \Serializable
 
         this->di->applyHook("model.after.validate", [this]);
 
-        if count(this->messages) {
+        if !empty this->messages {
             // Rollback changes and restore old data
             this->setData(data);
             return false;
@@ -398,6 +407,8 @@ abstract class Model extends Arr implements \Serializable
         if !status {
             // Rollback changes and restore old data
             this->setData(data);
+        } else {        
+            let this->isLoaded = true;
         }
 
         this->di->applyHook("model.after.update", [this]);
@@ -466,6 +477,11 @@ abstract class Model extends Arr implements \Serializable
         }
 
         let status = this->db->remove(this->from, filters);
+        
+        if status {
+            // this model doesn't exist in db
+            let this->isLoaded = false;
+        }
 
         return status;
     }
@@ -479,6 +495,10 @@ abstract class Model extends Arr implements \Serializable
     public function exists(var filters = [])
     {
         var key;
+
+        if this->isLoaded !== null {
+            return this->isLoaded ? this : false;
+        }
 
         if !filters {
             let filters = [];
@@ -500,7 +520,7 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        return self::findOne(filters);
+        return static::findOne(filters);
     }
 
     /**
@@ -715,6 +735,7 @@ abstract class Model extends Arr implements \Serializable
             } elseif typeof fields == "string" && isset this->rules[fields] {
                 return this->rules[fields];
             }
+            return null;
         }
 
         return this->rules;

--- a/ice/mvc/model.zep
+++ b/ice/mvc/model.zep
@@ -192,7 +192,7 @@ abstract class Model extends Arr implements \Serializable
 
         let model = create_instance_params(get_called_class(), [filters, null, options]);
 
-        return model->isLoaded ? instance : false;
+        return model->isLoaded ? model : false;
     }
 
     /**


### PR DESCRIPTION
1) no exception when create model by filters, you can test if it exists in db by `(new iModel(['id' => 9]))->exists()`
2) fixed fineOne initial order: `onConstruct` --> load data from service --> `initialize`. 
    the original order is: `onConstruct` --> `initialize` --> load data from service.
3) only reset primary key after insert if the primary key is `autoincrement`
4) minus enhancements
5) disallow empty filters for `loadOne`
6) fixed `getRules('zzz')` will return all rules
7) getRelated filter with options works for has_one