### PR TITLE
Di, fixed resolve bug

### DIFF
--- a/ice/di.zep
+++ b/ice/di.zep
@@ -129,7 +129,7 @@ class Di extends Arr
                 // Array definitions store class name at first parameter
                 if typeof service == "array" {
                     let params = current(service),
-                        service = this->build(key(service), (array)params);
+                        service = this->build(key(service), typeof params == "array" ? params : [params]);
                 }
             }
         }

--- a/ice/di.zep
+++ b/ice/di.zep
@@ -129,7 +129,7 @@ class Di extends Arr
                 // Array definitions store class name at first parameter
                 if typeof service == "array" {
                     let params = current(service),
-                        service = this->build(key(service), params == "array" ? params : [params]);
+                        service = this->build(key(service), (array)params);
                 }
             }
         }


### PR DESCRIPTION
if pass array of class name with parameters array, it'll not work as expect.
fail case: `$di->resolve(['Ice\Test' => [1, 2, 3]]) `