### PR TITLE
Assets loading with themes and skins supported

### DIFF
--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -274,6 +274,9 @@ class Assets
         if target[0] == '/' {
             let destination = _SERVER["DOCUMENT_ROOT"] . uriMin;
         } else {
+            if source[-1] != '/' {
+                let source = source . "/";
+            }
             let destination = source . uriMin;
         }
 

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -264,7 +264,7 @@ class Assets
      */
     protected function prepare(string! uri, var minify)
     {
-        var source, target, file, uriMin, destination, md5Old, md5New, old, minified;
+        var source, target, file, type, uriMin, destination, md5Old, md5New, old, minified;
 
         let source = this->getOption("source"),
             target = this->getOption("target"),

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -291,13 +291,13 @@ class Assets
             throw new Exception(["The request assets do not exist: %s", source]);
         }
 
-        if empty target {
-            let target = "min";
+        if !empty target {
+            let target = "/" . trim(str_replace("\\", "/", target), "/");
         } else {
-            let target = trim(str_replace("\\", "/", target), "/");
+            let target = "";
         }
 
-        let uriMin = "/" . target . "/" . dirname(uri) . "/";
+        let uriMin = target . "/" . dirname(uri) . "/";
 
         // cache min files place to document root always
         let destination = _SERVER["DOCUMENT_ROOT"] . uriMin,

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -304,7 +304,7 @@ class Assets
                 // new version found
                 let md5file = null;
                 // delete the old version
-                @unlink(md5file);
+                unlink(md5file);
             } else {
                 let uriMin .= file . "." . md5New . "." . type;
             }

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -264,7 +264,8 @@ class Assets
      */
     protected function prepare(string! uri, var minify)
     {
-        var source, target, file, type, uriMin, destination, md5Old, md5New, old, minified;
+        var source, target, file, type, uriMin, destination,
+            md5file, md5Old, md5New, old, minified;
 
         let source = this->getOption("source"),
             target = this->getOption("target"),

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -258,17 +258,23 @@ class Assets
             dir = dirname(uri) . DIRECTORY_SEPARATOR,
             file = basename(uri, "." . type),
             uriMin = target . dir . file . ".min." . type,
-            destination = _SERVER["DOCUMENT_ROOT"] . uriMin,
             exist = false;
 
         // there is no source dir, try to load from document root
-        if !starts_with("/", uri) && empty source {
+        if uri[0] != '/' && empty source {
             let uri = "/" . uri;
         }
 
         // uri is start from absolute path, try to load from document root
-        if starts_with("/", uri) || empty source {
+        if uri[0] == '/' || empty source {
             let source = _SERVER["DOCUMENT_ROOT"];
+        }
+
+        // target is start from absolute path, place min file to document root
+        if target[0] == '/' {
+            let destination = _SERVER["DOCUMENT_ROOT"] . uriMin;
+        } else {
+            let destination = source . uriMin;
         }
 
         switch minify {

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -330,8 +330,7 @@ class Assets
                     throw new Exception(["Directory can't be written: %s", destination]);
                 }
             } elseif copy(source, destination) === false {
-                    throw new Exception(["Directory can't be written: %s", destination]);
-                }
+                throw new Exception(["Directory can't be written: %s", destination]);
             }
         }
         return uriMin;

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -277,7 +277,7 @@ class Assets
         if uri[0] == '/' || empty source {
             let source = _SERVER["DOCUMENT_ROOT"];
         } else {
-            let source = str_replace(DIRECTORY_SEPARATOR, "/", source);
+            let source = str_replace("\\", "/", source);
         }
 
         if (source[-1] != '/') {
@@ -294,7 +294,7 @@ class Assets
         if empty target {
             let target = "min";
         } else {
-            let target = trim(str_replace(DIRECTORY_SEPARATOR, "/", target), "/");
+            let target = trim(str_replace("\\", "/", target), "/");
         }
 
         let uriMin = "/" . target . "/" . dirname(uri) . "/";

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -268,7 +268,7 @@ class Assets
             md5file, md5Old, md5New, old, minified;
 
         let source = this->getOption("source"),
-            target = this->getOption("target"),
+            target = str_replace(DIRECTORY_SEPARATOR, "/", this->getOption("target")),
             file = pathinfo(uri, PATHINFO_FILENAME | PATHINFO_EXTENSION),
             type = file["extension"],
             file = file["filename"];
@@ -276,6 +276,8 @@ class Assets
         // uri is start from absolute path, try to load from document root
         if uri[0] == '/' || empty source {
             let source = _SERVER["DOCUMENT_ROOT"];
+        } else {
+            let source = str_replace(DIRECTORY_SEPARATOR, "/", source);
         }
 
         if (source[-1] != '/') {

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -325,7 +325,7 @@ class Assets
                 destination = _SERVER["DOCUMENT_ROOT"] . uriMin;
 
             if minify {
-                minified = this->minify(file_get_contents(source), type);
+                let minified = this->minify(file_get_contents(source), type);
                 if file_put_contents(destination, minified) === false {
                     throw new Exception(["Directory can't be written: %s", destination]);
                 }

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -268,7 +268,7 @@ class Assets
             md5file, md5Old, md5New, old, minified;
 
         let source = this->getOption("source"),
-            target = str_replace(DIRECTORY_SEPARATOR, "/", this->getOption("target")),
+            target = this->getOption("target"),
             file = pathinfo(uri, PATHINFO_FILENAME | PATHINFO_EXTENSION),
             type = file["extension"],
             file = file["filename"];
@@ -291,7 +291,13 @@ class Assets
             throw new Exception(["The request assets do not exist: %s", source]);
         }
 
-        let uriMin = "/" . trim(target, "/") . "/" . dirname(uri) . "/";
+        if empty target {
+            let target = "min";
+        } else {
+            let target = trim(str_replace(DIRECTORY_SEPARATOR, "/", target), "/");
+        }
+
+        let uriMin = "/" . target . "/" . dirname(uri) . "/";
 
         // cache min files place to document root always
         let destination = _SERVER["DOCUMENT_ROOT"] . uriMin,

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -258,8 +258,18 @@ class Assets
             dir = dirname(uri) . DIRECTORY_SEPARATOR,
             file = basename(uri, "." . type),
             uriMin = target . dir . file . ".min." . type,
-            destination = source . uriMin,
+            destination = _SERVER["DOCUMENT_ROOT"] . uriMin,
             exist = false;
+
+        // there is no source dir, try to load from document root
+        if uri[0] != "/" && empty source {
+            let uri = "/" . uri;
+        }
+
+        // uri is start from absolute path, try to load from document root
+        if uri[0] == "/" || empty source {
+            let source = _SERVER["DOCUMENT_ROOT"];
+        }
 
         switch minify {
             case self::NOT_EXIST:

--- a/ice/assets.zep
+++ b/ice/assets.zep
@@ -262,12 +262,12 @@ class Assets
             exist = false;
 
         // there is no source dir, try to load from document root
-        if uri[0] != "/" && empty source {
+        if !starts_with("/", uri) && empty source {
             let uri = "/" . uri;
         }
 
         // uri is start from absolute path, try to load from document root
-        if uri[0] == "/" || empty source {
+        if starts_with("/", uri) || empty source {
             let source = _SERVER["DOCUMENT_ROOT"];
         }
 


### PR DESCRIPTION
Assets loading with themes and skins supported. assume that different apps (or plugins) are independent with each others but share the same basic modules and public resources

A) asset cases: there are stylesheet files in public `css` share by all apps 
and app specific stylesheet locate in its directory. e.g.
 -  public/css/style.css
 -  public/min/css/style.min.css
 -  app/account/skin/default/css/account.css
 -  public/min/css/account.min.css

B) loading source and target
   1.  load the min file
        - a) load from public:  /css/style.css ===> public/min/css/style.min.css
              minify `public/css/style.css` to `public/min/css/style.min.css`
        - b) load from app dir: css/account.css ===> public/min/css/account.min.css
              minify `account/default/css/account.css` to `public/min/css/account.min.css`
   2.  load the raw file
        - a) load from public: /css/style.css ===> public/css/style.css
        - b) load from app dir: default/css/account.css ===> public/default/css/account.css
            - i) if `public/default/css/account.css` not exists, 
                copy `account/default/css/account.css` to `public/default/css/`
            - ii) else update `account/default/css/account.css` to `public/default/css/`

C) implement

1) if `uri` is start with `/`, it'll try to load asset from document root
```php

$mySkin = 'Default';

// Register specific services for the module
public function registerServices(Di $di)
{
    $di->assets->setOptions([
            'source' => __DIR__ . '/Skin/' . $mySkin . '/',
            'target' => 'min/',
            'minify' => 3
        ]);
}

// css used by specific module
// load from module dir/Skin/Default/css/account.css
$this->assets->addCss(['css/account.css']); 

// css shared by all modules
// load from document_root/Skin/Default/css/style.css
$this->assets->addCss(['/Skin/' . $mySkin . '/css/style.css']); 
```
2) always store the min files in the document_root/target dir

**ONE MORE THING**

`type` parameter change from `text/css` or `text/javascript` to `css` or `js`
```php
$assets->addCss(['css/style.css', 'type' => 'css'])
->addCss(['js/script.js', 'type' => 'js'])
```
but not
```php
$assets->addCss(['css/style.css', 'type' => 'text/css'])
->addCss(['js/script.js', 'type' => 'text/javascript'])