### PR TITLE
Model, hook bug fixed #208

### DIFF
--- a/ice/mvc/model.zep
+++ b/ice/mvc/model.zep
@@ -299,7 +299,7 @@ abstract class Model extends Arr implements \Serializable
             let this->messages = [];
         }
 
-        this->di->applyHook("model.before.validate", [this]);
+        this->di->applyHook("model.before.validate." . static::class, [this]);
 
         // Run validation if rules or validation is specified
         if !empty this->rules || typeof this->validation == "object" && (this->validation instanceof Validation) {
@@ -324,13 +324,13 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.validate", [this]);
+        this->di->applyHook("model.after.validate." . static::class, [this]);
 
         if !empty this->messages {
             return null;
         }
 
-        this->di->applyHook("model.before.create", [this]);
+        this->di->applyHook("model.before.create." . static::class, [this]);
 
         let status = this->db->insert(this->from, this->getData());
 
@@ -341,7 +341,7 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.create", [this]);
+        this->di->applyHook("model.after.create." . static::class, [this]);
 
         return status;
     }
@@ -385,7 +385,7 @@ abstract class Model extends Arr implements \Serializable
             let this->messages = [];
         }
 
-        this->di->applyHook("model.before.validate", [this]);
+        this->di->applyHook("model.before.validate." . static::class, [this]);
 
         if typeof this->validation == "object" && (this->validation instanceof Validation) {
             this->validation->validate(this->getData());
@@ -398,7 +398,7 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.validate", [this]);
+        this->di->applyHook("model.after.validate." . static::class, [this]);
 
         if !empty this->messages {
             // Rollback changes and restore old data
@@ -406,7 +406,7 @@ abstract class Model extends Arr implements \Serializable
             return null;
         }
 
-        this->di->applyHook("model.before.update", [this]);
+        this->di->applyHook("model.before.update." . static::class, [this]);
 
         let fields = this->fields(this->getData(), !this->autoincrement);
 
@@ -423,7 +423,7 @@ abstract class Model extends Arr implements \Serializable
             let this->isLoaded = true;
         }
 
-        this->di->applyHook("model.after.update", [this]);
+        this->di->applyHook("model.after.update." . static::class, [this]);
 
         return status;
     }

--- a/ice/mvc/model.zep
+++ b/ice/mvc/model.zep
@@ -162,7 +162,7 @@ abstract class Model extends Arr implements \Serializable
 
         if result->count() {
             for data in iterator(result) {
-                let model = create_instance_params(get_called_class(), [null, data]),
+                let model = create_instance_params(static::$class, [null, data]),
                     model->isLoaded = true,
                     instances[] = model;
             }
@@ -190,7 +190,7 @@ abstract class Model extends Arr implements \Serializable
     {
         var model;
 
-        let model = create_instance_params(get_called_class(), [filters, null, options]);
+        let model = create_instance_params(static::$class, [filters, null, options]);
 
         return model->isLoaded ? model : false;
     }
@@ -211,7 +211,7 @@ abstract class Model extends Arr implements \Serializable
     {
         var model;
 
-        let model = create_instance(get_called_class());
+        let model = create_instance(static::$class);
 
         return model->load(filters, options);
     }
@@ -299,7 +299,7 @@ abstract class Model extends Arr implements \Serializable
             let this->messages = [];
         }
 
-        this->di->applyHook("model.before.validate." . static::class, [this]);
+        this->di->applyHook("model.before.validate." . static::$class, [this]);
 
         // Run validation if rules or validation is specified
         if !empty this->rules || typeof this->validation == "object" && (this->validation instanceof Validation) {
@@ -324,13 +324,13 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.validate." . static::class, [this]);
+        this->di->applyHook("model.after.validate." . static::$class, [this]);
 
         if !empty this->messages {
             return null;
         }
 
-        this->di->applyHook("model.before.create." . static::class, [this]);
+        this->di->applyHook("model.before.create." . static::$class, [this]);
 
         let status = this->db->insert(this->from, this->getData());
 
@@ -341,7 +341,7 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.create." . static::class, [this]);
+        this->di->applyHook("model.after.create." . static::$class, [this]);
 
         return status;
     }
@@ -385,7 +385,7 @@ abstract class Model extends Arr implements \Serializable
             let this->messages = [];
         }
 
-        this->di->applyHook("model.before.validate." . static::class, [this]);
+        this->di->applyHook("model.before.validate." . static::$class, [this]);
 
         if typeof this->validation == "object" && (this->validation instanceof Validation) {
             this->validation->validate(this->getData());
@@ -398,7 +398,7 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.validate." . static::class, [this]);
+        this->di->applyHook("model.after.validate." . static::$class, [this]);
 
         if !empty this->messages {
             // Rollback changes and restore old data
@@ -406,7 +406,7 @@ abstract class Model extends Arr implements \Serializable
             return null;
         }
 
-        this->di->applyHook("model.before.update." . static::class, [this]);
+        this->di->applyHook("model.before.update." . static::$class, [this]);
 
         let fields = this->fields(this->getData(), !this->autoincrement);
 
@@ -423,7 +423,7 @@ abstract class Model extends Arr implements \Serializable
             let this->isLoaded = true;
         }
 
-        this->di->applyHook("model.after.update." . static::class, [this]);
+        this->di->applyHook("model.after.update." . static::$class, [this]);
 
         return status;
     }

--- a/ice/mvc/model.zep
+++ b/ice/mvc/model.zep
@@ -162,7 +162,7 @@ abstract class Model extends Arr implements \Serializable
 
         if result->count() {
             for data in iterator(result) {
-                let model = create_instance_params(static::$class, [null, data]),
+                let model = create_instance_params(get_called_class(), [null, data]),
                     model->isLoaded = true,
                     instances[] = model;
             }
@@ -190,7 +190,7 @@ abstract class Model extends Arr implements \Serializable
     {
         var model;
 
-        let model = create_instance_params(static::$class, [filters, null, options]);
+        let model = create_instance_params(get_called_class(), [filters, null, options]);
 
         return model->isLoaded ? model : false;
     }
@@ -211,7 +211,7 @@ abstract class Model extends Arr implements \Serializable
     {
         var model;
 
-        let model = create_instance(static::$class);
+        let model = create_instance(get_called_class());
 
         return model->load(filters, options);
     }
@@ -287,7 +287,7 @@ abstract class Model extends Arr implements \Serializable
      */
     public function create(var fields = [], <Validation> extra = null)
     {
-        var status;
+        var status, called;
 
         this->setData(this->fields(fields, !this->autoincrement));
 
@@ -299,7 +299,9 @@ abstract class Model extends Arr implements \Serializable
             let this->messages = [];
         }
 
-        this->di->applyHook("model.before.validate." . static::$class, [this]);
+        let called = get_called_class();
+
+        this->di->applyHook("model.before.validate." . called, [this]);
 
         // Run validation if rules or validation is specified
         if !empty this->rules || typeof this->validation == "object" && (this->validation instanceof Validation) {
@@ -324,13 +326,13 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.validate." . static::$class, [this]);
+        this->di->applyHook("model.after.validate." . called, [this]);
 
         if !empty this->messages {
             return null;
         }
 
-        this->di->applyHook("model.before.create." . static::$class, [this]);
+        this->di->applyHook("model.before.create." . called, [this]);
 
         let status = this->db->insert(this->from, this->getData());
 
@@ -341,7 +343,7 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.create." . static::$class, [this]);
+        this->di->applyHook("model.after.create." . called, [this]);
 
         return status;
     }
@@ -362,7 +364,7 @@ abstract class Model extends Arr implements \Serializable
      */
     public function update(var fields = [], <Validation> extra = null)
     {
-        var data, status, primary, key;
+        var data, status, primary, key, called;
 
         let data = this->getData(),
             primary = [];
@@ -385,7 +387,9 @@ abstract class Model extends Arr implements \Serializable
             let this->messages = [];
         }
 
-        this->di->applyHook("model.before.validate." . static::$class, [this]);
+        let called = get_called_class();
+
+        this->di->applyHook("model.before.validate." . called, [this]);
 
         if typeof this->validation == "object" && (this->validation instanceof Validation) {
             this->validation->validate(this->getData());
@@ -398,7 +402,7 @@ abstract class Model extends Arr implements \Serializable
             }
         }
 
-        this->di->applyHook("model.after.validate." . static::$class, [this]);
+        this->di->applyHook("model.after.validate." . called, [this]);
 
         if !empty this->messages {
             // Rollback changes and restore old data
@@ -406,7 +410,7 @@ abstract class Model extends Arr implements \Serializable
             return null;
         }
 
-        this->di->applyHook("model.before.update." . static::$class, [this]);
+        this->di->applyHook("model.before.update." . called, [this]);
 
         let fields = this->fields(this->getData(), !this->autoincrement);
 
@@ -423,7 +427,7 @@ abstract class Model extends Arr implements \Serializable
             let this->isLoaded = true;
         }
 
-        this->di->applyHook("model.after.update." . static::$class, [this]);
+        this->di->applyHook("model.after.update." . called, [this]);
 
         return status;
     }

--- a/tests/App/Models/Users.php
+++ b/tests/App/Models/Users.php
@@ -29,7 +29,7 @@ class Users extends IceUsers
     {
         $model = $this;
 
-        $this->di->hook('model.before.create', function ($model) {
+        $this->di->hook('model.before.create.' . get_called_class(), function ($model) {
             $model->set('password', md5($model->get('password')));
             $model->set('logins', intval($model->get('logins')));
         });


### PR DESCRIPTION
add model hooks will has to append current classname as prefix now.
previous
```php
$this->di->hook("model.after.update", function(){ });
```
now
```php
$this->di->hook("model.after.update." . static::class, function(){ });