### PR TITLE
fix build with recent GCC

### DIFF
--- a/build/php7/ice.c
+++ b/build/php7/ice.c
@@ -21,6 +21,9 @@
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
 
+#ifdef ZTS
+ZEND_TSRMLS_CACHE_DEFINE()
+#endif
 
 
 zend_class_entry *ice_i18n_plural_pluralinterface_ce;
@@ -320,9 +323,6 @@ static void php_zephir_init_module_globals(zend_ice_globals *ice_globals TSRMLS_
 static PHP_RINIT_FUNCTION(ice)
 {
 	zend_ice_globals *ice_globals_ptr;
-#ifdef ZTS
-	tsrm_ls = ts_resource(0);
-#endif
 	ice_globals_ptr = ZEPHIR_VGLOBAL;
 
 	php_zephir_init_globals(ice_globals_ptr);
@@ -368,6 +368,9 @@ static PHP_MINFO_FUNCTION(ice)
 
 static PHP_GINIT_FUNCTION(ice)
 {
+#ifdef ZTS
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
 	php_zephir_init_globals(ice_globals);
 	php_zephir_init_module_globals(ice_globals);
 }

--- a/build/php7/php_ice.h
+++ b/build/php7/php_ice.h
@@ -53,7 +53,7 @@ ZEND_EXTERN_MODULE_GLOBALS(ice)
 #endif
 
 #ifdef ZTS
-	void ***tsrm_ls;
+	ZEND_TSRMLS_CACHE_EXTERN()
 	#define ZEPHIR_VGLOBAL ((zend_ice_globals *) (*((void ***) tsrm_get_ls_cache()))[TSRM_UNSHUFFLE_RSRC_ID(ice_globals_id)])
 #else
 	#define ZEPHIR_VGLOBAL &(ice_globals)


### PR DESCRIPTION
Trying to build with GCC 10
```
/usr/bin/ld: kernel/.libs/main.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defi
ned here
/usr/bin/ld: kernel/.libs/memory.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first de
fined here
/usr/bin/ld: kernel/.libs/exception.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first
 defined here
/usr/bin/ld: kernel/.libs/debug.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first def
ined here
/usr/bin/ld: kernel/.libs/object.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defined here
/usr/bin/ld: kernel/.libs/array.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defined here
/usr/bin/ld: kernel/.libs/string.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defined here
/usr/bin/ld: kernel/.libs/fcall.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defined here
/usr/bin/ld: kernel/.libs/require.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defined here
/usr/bin/ld: kernel/.libs/file.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defined here
/usr/bin/ld: kernel/.libs/operators.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defined here
/usr/bin/ld: kernel/.libs/math.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/./php_ice.h:56: multiple definition of `tsrm_ls'; .libs/ice.o:/builddir/build/BUILD/php-pecl-ice-1.6.0/ZTS/php_ice.h:56: first defi
...
```

Use PHP 7 ZEND_TSRMLS_CACHE way instead (tsrm_ls is no more needed)
