### PR TITLE
Could not load ice on alpine

### DIFF
--- a/build/php8/config.m4
+++ b/build/php8/config.m4
@@ -175,6 +175,9 @@ if test "$PHP_ICE" = "yes"; then
 	)
 
 	CPPFLAGS=$old_CPPFLAGS
+	if test -f "/etc/alpine-release" ; then
+		LDFLAGS="$LDFLAGS -lexecinfo"
+	fi
 
 	PHP_INSTALL_HEADERS([ext/ice], [php_ICE.h])
 


### PR DESCRIPTION
Hi @mruz,

Following https://github.com/the-benchmarker/web-frameworks/pull/3655#issuecomment-821187318, I added a flag on `phpize` for **alpine** (first time I do such a thing).

@see https://github.com/DataDog/dd-trace-php/issues/312

This allow support for **alpine** since I have a debug symbol loading issue (and then extension could not be loaded).

Regards,

PS : I'm not sure why this debug symbol is required, btw

PSS : I'm not sure travis will help, if you want that `ice` support **alpine**